### PR TITLE
Remove extra misplaced links to Microbyte's RSS feed and replace dead links with archives

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,6 @@
 
 			<li data-lang="en" id="nhkcafe">
 				<a href="https://nhkhq.neocities.org/">NHKCAFE</a>
-				<a href="https://microbyte.neocities.org/index.xml" class="rss">rss</a>
 				<img loading="lazy" src='https://nhkhq.neocities.org/assets/nhkWebButton.png' width="88" height="31">
 			</li>
 
@@ -140,13 +139,12 @@
 			</li>
 
 			<li data-lang="en" id="yuiuimoe">
-				<a href="https://yuiui.moe/">yuiui.moe</a>
-				<img loading="lazy" src='http://yuiui.moe/img/button.png' width="88" height="31">
+				<a href="https://web.archive.org/web/20250126224258/https://yuiui.moe/">yuiui.moe (archived)</a>
+				<img loading="lazy" src='https://web.archive.org/web/20250310050930/http://yuiui.moe/img/button.png' width="88" height="31">
 			</li>
 
 			<li data-lang="en" id="splashy">
 				<a href="https://splashy.neocities.org/">splashy</a>
-				<a href="https://microbyte.neocities.org/index.xml" class="rss">rss</a>
 				<img loading="lazy" src='https://splashy.neocities.org/splashy.gif' width="88" height="31">
 			</li>
 


### PR DESCRIPTION
The link to Microbyte's RSS feed was pasted in random spots (including mine lol), so i've removed those misplaced pastes of the link. yuiui's page is (as of now) dead, so I've replaced links for his page's index and button with Wayback Machine archives. I've also added (archived) to the title of the site to indicate that the link will take you to an archive.