### PR TITLE
Improve mobile responsiveness, center content in grid

### DIFF
--- a/res/styles.css
+++ b/res/styles.css
@@ -63,8 +63,6 @@ main > ol {
 }
 
 main > ol > li {
-    page-break-inside: avoid;
-    break-inside: avoid;
     padding: 0;
     max-width: 250px;
 }

--- a/res/styles.css
+++ b/res/styles.css
@@ -59,13 +59,14 @@ main > ol {
     column-gap: 30px;
     border-bottom: 2px solid var(--color-beta);
     padding-bottom: 30px;
+    min-width: 800px;
 }
 
 main > ol > li {
     page-break-inside: avoid;
     break-inside: avoid;
     padding: 0;
-    max-width: 205px;
+    max-width: 250px;
 }
 
 main > ol > li img {
@@ -119,12 +120,13 @@ main {
 }
 
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 820px) {
     main > ol {
         grid-template-columns: 50% 50%;
         gap: 0;
         width: 600px;
         padding-left: 0;
+        min-width: 0;
     }
 
     main > ol > li {
@@ -140,11 +142,11 @@ main {
     }
 
     main > ol > li img {
-        margin: 5px auto 10px auto;
+        margin: 5px auto 15px auto;
     }
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 550px) {
     main > ol {
         grid-template-columns: 100%;
     }

--- a/res/styles.css
+++ b/res/styles.css
@@ -39,7 +39,7 @@ body footer a {
     text-decoration: none;
 }
 
-body a:hover {
+body a:hover, body a:active {
     background-color: var(--color-beta);
     color: var(--color-alpha);
 }

--- a/res/styles.css
+++ b/res/styles.css
@@ -53,17 +53,19 @@ body a:after {
 }
 
 main > ol {
-    margin: 30px;
-    padding: 0px 30px 30px;
-    column-count: 3;
-    display: block;
+    display: grid;
+    grid-template-columns: 33% 33% 33%;
+    row-gap: 10px;
+    column-gap: 30px;
     border-bottom: 2px solid var(--color-beta);
+    padding-bottom: 30px;
 }
 
 main > ol > li {
-    padding-right: 30px;
     page-break-inside: avoid;
     break-inside: avoid;
+    padding: 0;
+    max-width: 205px;
 }
 
 main > ol > li img {
@@ -110,15 +112,55 @@ body > ol > li:target {
     background: var(--color-beta);
 }
 
+main {
+    display: flex;
+    justify-content: center;
+    margin: 0 auto;
+}
+
+
 @media screen and (max-width: 800px) {
-    body > ol {
-        column-count: 2;
+    main > ol {
+        grid-template-columns: 50% 50%;
+        gap: 0;
+        width: 600px;
+        padding-left: 0;
+    }
+
+    main > ol > li {
+        width: 200px;
+        white-space: wrap;
+        overflow-wrap: break-word;
+        text-align: center;
+    }
+
+    ol > li {
+        justify-self: center;
+        align-self: center;
+    }
+
+    main > ol > li img {
+        margin: 5px auto 10px auto;
     }
 }
 
 @media screen and (max-width: 600px) {
-    body > ol {
-        column-count: 1;
+    main > ol {
+        grid-template-columns: 100%;
+    }
+}
+
+@media screen and (max-width: 300px) {
+    main > ol > li {
+        white-space: wrap;
+        width: 150px;
+    }
+}
+
+@media screen and (max-width: 200px) {
+    main > ol > li {
+        white-space: wrap;
+        width: 100px;
     }
 }
 


### PR DESCRIPTION
My phone is quite narrow and has issues with alignment and centering on mobile devices. I've swapped the CSS over to using the flexbox grid which allows me better control over centering the elements inside the grid.

I've also updated the mobile breakpoints to prevent the clipping and misalignment, collapse into columns as expected and still appear correctly centered regardless of the breakpoint CSS being hit

Below are some comparisons between my revision and your master branch head:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/e030b285-d2dc-40ca-b6d2-c0bb4ceebb77" />

`<li>`s now appear in-line with the heading text

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/77ac190a-edea-409e-993c-d7e787e915bd" />

Grid items now aligned (mostly) correctly, and centered on the document

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/3e8c37c4-f80c-4f5f-b0e2-158c47b7a31f" />

Mobile breakpoints now behaving well and remaining centered 